### PR TITLE
Add support for android auto

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -79,6 +79,9 @@
         <meta-data
             android:name="io.flutter.embedding.android.EnableImpeller"
             android:value="false" />
+        <meta-data
+            android:name="com.google.android.gms.car.application"
+            android:resource="@xml/automotive_app_desc" />
     </application>
     <!-- Required to query activities that can process text, see:
          https://developer.android.com/training/package-visibility and

--- a/android/app/src/main/res/xml/automotive_app_desc.xml
+++ b/android/app/src/main/res/xml/automotive_app_desc.xml
@@ -1,0 +1,3 @@
+<automotiveApp>
+    <uses name="media"/>
+</automotiveApp>


### PR DESCRIPTION
**Changes**

- Adds support for android auto using default layout. #179 

Note: This need developer option to be enabled for non google play apps. Goto `Settings -> Android Auto -> About -> Tap Version info 10 times` to enable. Make sure app is selected under `Display -> Customize launcher`

**Screenshots**
<img width="241" alt="Capture" src="https://github.com/user-attachments/assets/6811237b-9c68-4d5c-ac28-dc20407d4284" />
<img width="601" alt="Capture-3" src="https://github.com/user-attachments/assets/cec5f3b7-cfe8-407d-81d5-ad8b1a4ba19d" />